### PR TITLE
stop showing ids in multiselect dropdown

### DIFF
--- a/app/src/api/services/autofill.ts
+++ b/app/src/api/services/autofill.ts
@@ -1,7 +1,6 @@
 import db from '../../db';
 
 interface AutofillOption {
-    id: string;
     value: string;
     similarity?: number;
 }
@@ -17,7 +16,6 @@ function getLanduseGroupOptions(value: string, all: boolean = false) {
     if(all) {
         return db.manyOrNone(`
             SELECT
-                landuse_id AS id,
                 description AS value
             FROM reference_tables.buildings_landuse_group
             `

--- a/app/src/frontend/building/data-components/autofill-dropdown/autofill-dropdown.tsx
+++ b/app/src/frontend/building/data-components/autofill-dropdown/autofill-dropdown.tsx
@@ -60,7 +60,6 @@ export const AutofillDropdown: React.FC<AutofillDropdownProps> =  props => {
             {
                 options.map(option =>
                     <div
-                        key={option.id}
                         onMouseDown={e => /* prevent input blur */ e.preventDefault()}
                         onClick={e => {
                             props.onSelect(option.value);
@@ -68,7 +67,7 @@ export const AutofillDropdown: React.FC<AutofillDropdownProps> =  props => {
                             props.onClose();
                         }}
                     >
-                        {option.value} ({option.id})
+                        {option.value}
                     </div>)
             }
         </div>


### PR DESCRIPTION
it is not really needed for users, not critical for debugging, showing this ids is not helpful and rather confusing
especially as you cannot search for entries using them
it gets worse for #727 (secondary material multiselect dropdown) as materials have only names, not ids

![screen](https://user-images.githubusercontent.com/899988/154659571-bb36ea37-5851-4c99-9096-d932ba6358e0.png)

before this change WIP for #727 had following display (landuse mentioned here in prefill is obviously also going to be fixed):

![screen01](https://user-images.githubusercontent.com/899988/154481544-763976cd-8935-449c-988b-9a754543751f.png)