### PR TITLE
Add News and Discussions Links

### DIFF
--- a/app/src/frontend/header.tsx
+++ b/app/src/frontend/header.tsx
@@ -84,6 +84,11 @@ function getCurrentMenuLinks(username: string): MenuLink[][] {
                 external: true
             },
             {
+                to: "https://github.com/colouring-cities/manual/wiki/M3.1-News",
+                text: "Colouring London News",
+                external: true
+            },
+            {
                 to: "https://github.com/colouring-cities/manual/wiki/A2.-How-to%3F-Guides",
                 text: "How to Use",
                 external: true
@@ -110,15 +115,15 @@ function getCurrentMenuLinks(username: string): MenuLink[][] {
                 text: "Top Contributors"
             },
             {
+                to: "https://discuss.colouring.london/",
+                text: "Colouring London Discussions Forum",
+                external: true
+            },
+            {
                 to: config.githubURL+"/discussions",
                 text: "Discussion Forum (GitHub)",
                 external: true
             },
-            // {
-            //     to: "https://discuss.colouring.london/c/blog/9",
-            //     text: "Blog",
-            //     external: true
-            // },
         ],
         [
             {


### PR DESCRIPTION
- Restore the link to the Colouring London discussions page (in addition to the GitHub link) #28
- Add a link to the new News page #29