### PR TITLE
Add configuration option for tile bbox

### DIFF
--- a/app/src/cc-config.json
+++ b/app/src/cc-config.json
@@ -10,5 +10,7 @@
     "initialZoomLevel": 16,
 
     "postcode": "Postcode",
-    "energy_rating": "Building Research Establishment Environmental Assessment Method (BREEAM) rating [<a href='https://bregroup.com/products/breeam/how-breeam-works'>More info</a>]"
+    "energy_rating": "Building Research Establishment Environmental Assessment Method (BREEAM) rating [<a href='https://bregroup.com/products/breeam/how-breeam-works'>More info</a>]",
+
+    "bbox": [-61149.622628, 6667754.851372, 37183, 6744803.375884]
 }

--- a/app/src/cc-config.ts
+++ b/app/src/cc-config.ts
@@ -14,5 +14,7 @@ export interface CCConfig
 
     postcode: string;                           // Alternative for "Postcode" text (i.e. "Zip Code")
     energy_rating: string;                      // Official Environmental Energy Rating (BREEAM Rating in UK)
+
+    bbox: [number, number, number, number];     // Bounding box of generated tiles, in CRS epsg:3857 in form: [w, s, e, n]
 }
 

--- a/app/src/tiles/rendererDefinition.ts
+++ b/app/src/tiles/rendererDefinition.ts
@@ -7,6 +7,8 @@ import { stitchTile } from "./renderers/stitchTile";
 import { TileCache } from "./tileCache";
 import { BoundingBox, Tile, TileParams } from "./types";
 import { isOutsideExtent } from "./util";
+import { CCConfig } from '../cc-config';
+let config: CCConfig = require('../cc-config.json')
 
 /**
  * A list of all tilesets handled by the tile server
@@ -21,9 +23,8 @@ const STITCH_THRESHOLD = 12;
 
 /**
  * Hard-code extent so we can short-circuit rendering and return empty/transparent tiles outside the area of interest
- * bbox in CRS epsg:3857 in form: [w, s, e, n]
  */
-const EXTENT_BBOX: BoundingBox = [-61149.622628, 6667754.851372, 37183, 6744803.375884];
+const EXTENT_BBOX: BoundingBox = config.bbox;
 
 const allLayersCacheSwitch = parseBooleanExact(process.env.CACHE_TILES) ?? true;
 const dataLayersCacheSwitch = parseBooleanExact(process.env.CACHE_DATA_TILES) ?? true;


### PR DESCRIPTION
partially addresses #1284

tested with `"bbox": [-13821, 6707971, -7886, 6711363]`

![screen06](https://github.com/colouring-cities/colouring-core/assets/899988/6062d0b3-89b1-44cd-bc40-8a72bf55cad6)
