### PR TITLE
Log caching errors.

### DIFF
--- a/app/src/tiles/renderers/getTileWithCaching.ts
+++ b/app/src/tiles/renderers/getTileWithCaching.ts
@@ -10,7 +10,9 @@ async function getTileWithCaching(tileParams: TileParams, dataParams: any, tileC
         const im = await renderTile(tileParams, dataParams);
         try {
             await tileCache.put(im, tileParams);
-        } catch (err) {}
+        } catch (err) {
+            console.error(err);
+        }
         return im;
     }
 }


### PR DESCRIPTION
in normal operation it does not change anything
in case of errors happening it makes easier to track down what went wrong