### PR TITLE
Allow easier change of map tiles and attribution, use tiles with global coverage

### DIFF
--- a/app/src/cc-config.json
+++ b/app/src/cc-config.json
@@ -14,6 +14,6 @@
 
     "bbox": [-61149.622628, 6667754.851372, 37183, 6744803.375884],
 
-    "basemapTileUrl": "https://api.os.uk/maps/raster/v1/zxy/Light_3857/{z}/{x}/{y}.png?key=UVWEspgInusDKKYANE5bmyddoEmCSD4r",
-    "baseAttribution": "Building attribute data is © Colouring Cities contributors. Maps contain OS data © Crown copyright: OS Maps baselayers and building outlines. <a href=/ordnance-survey-licence.html>OS licence</a>"
+    "basemapTileUrl": "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+    "baseAttribution": "Building attribute data is © Colouring Cities contributors. Basemap © <a href=https://www.openstreetmap.org/copyright>OpenStreetMap contributors</a>. Building © MODIFY TO PROVIDE RELEVANT INFO"
 }

--- a/app/src/cc-config.json
+++ b/app/src/cc-config.json
@@ -12,5 +12,8 @@
     "postcode": "Postcode",
     "energy_rating": "Building Research Establishment Environmental Assessment Method (BREEAM) rating [<a href='https://bregroup.com/products/breeam/how-breeam-works'>More info</a>]",
 
-    "bbox": [-61149.622628, 6667754.851372, 37183, 6744803.375884]
+    "bbox": [-61149.622628, 6667754.851372, 37183, 6744803.375884],
+
+    "basemapTileUrl": "https://api.os.uk/maps/raster/v1/zxy/Light_3857/{z}/{x}/{y}.png?key=UVWEspgInusDKKYANE5bmyddoEmCSD4r",
+    "baseAttribution": "Building attribute data is © Colouring Cities contributors. Maps contain OS data © Crown copyright: OS Maps baselayers and building outlines. <a href=/ordnance-survey-licence.html>OS licence</a>"
 }

--- a/app/src/cc-config.ts
+++ b/app/src/cc-config.ts
@@ -16,5 +16,7 @@ export interface CCConfig
     energy_rating: string;                      // Official Environmental Energy Rating (BREEAM Rating in UK)
 
     bbox: [number, number, number, number];     // Bounding box of generated tiles, in CRS epsg:3857 in form: [w, s, e, n]
+    basemapTileUrl: string;
+    baseAttribution: string;
 }
 

--- a/app/src/frontend/map/layers/city-base-map-layer.tsx
+++ b/app/src/frontend/map/layers/city-base-map-layer.tsx
@@ -2,9 +2,8 @@ import * as React from 'react';
 import { TileLayer } from 'react-leaflet';
 
 import { MapTheme } from '../../config/map-config';
-
-const OS_API_KEY = 'UVWEspgInusDKKYANE5bmyddoEmCSD4r';
-
+import { CCConfig } from '../../../cc-config';
+let config: CCConfig = require('../../../cc-config.json')
 /**
  * Base raster layer for the map.
  * @param theme map theme
@@ -15,16 +14,11 @@ export function CityBaseMapLayer({ theme }: { theme: MapTheme }) {
      * Ordnance Survey maps - UK / London specific
      * (replace with appropriate base map for other cities/countries)
      */
-    const apiKey = OS_API_KEY;
-
-    // Note that OS APIs does not provide dark theme
-    const layer = 'Light_3857';
-
     // In either theme case, we will use OS's light theme, but add our own filter
     const theme_class = theme === 'light' ? "light-theme" : "night-theme";
 
-    const baseUrl = `https://api.os.uk/maps/raster/v1/zxy/${layer}/{z}/{x}/{y}.png?key=${apiKey}`;
-    const attribution = `Building attribute data is © Colouring Cities contributors. Maps contain OS data © Crown copyright: OS Maps baselayers and building outlines. <a href=/ordnance-survey-licence.html>OS licence</a>`;
+    const baseUrl = config.basemapTileUrl;
+    const attribution = config.baseAttribution;
 
     return <TileLayer
         url={baseUrl}

--- a/docs/configuring-colouring-cities.md
+++ b/docs/configuring-colouring-cities.md
@@ -17,7 +17,7 @@ The configuration files are located here:
 ### > cc-config.json
 The JSON file contains the definition of the values of the variables. 
 
-Currently, these parameters are:
+Currently, these parameters include:
 
 - **'cityName'** (string) - The name of the city/country. 
 - **'projectBlurb'** (string) - A line of text describing the relationship of the project to the CCRP
@@ -57,4 +57,4 @@ If you want to add additional parameters into the configuration framework, then 
   
 **NOTE: Any additional project specific text strings and parameters should be added to this file and the JSON file.**
 
-*REQUEST: If you find any Colouring London-specific text or values, please report them or create a pull request to move them into the configuration framework.*
+*REQUEST: If you find any London-specific text or values, please report them or create a pull request to move them into the configuration framework.*

--- a/docs/configuring-colouring-cities.md
+++ b/docs/configuring-colouring-cities.md
@@ -30,6 +30,8 @@ There are also some other values to customise the behaviour of the application:
 
 - **'initialMapPosition'** (string) - The default latitude and longitude of the map when the page loads. 
 - **'initialZoomLevel'** (string) - The default zoom level when the map loads. 
+- **'basemapTileUrl'** (string) - URL of basemap, in format accepted by Leaflet, shown under any displayed features. Note that default one is using external servers with own [Usage Policy](https://operations.osmfoundation.org/policies/tiles/) - please review it.
+- **'baseAttribution'** (string) - basic attribution, in format accepted by Leaflet, should include basemap attribution, attribution for work of Colouring platform contributors and likely also attribute source of building geometries. Default `baseAttribution` always needs to be edited, though it contains part of required attribution for attribute data and default basemap.
 
 For example, the [JSON file for Colouring London](https://github.com/colouring-cities/colouring-london/blob/master/app/src/cc-config.json) looks like this:
 


### PR DESCRIPTION
Move basemap layer configuration to configuration file.

fixes https://github.com/colouring-cities/colouring-core/issues/1284

Use OpenStreetMap tiles by default.

More friendly to new partners outside UK, less configuration will be typically required.

fixes https://github.com/colouring-cities/colouring-core/issues/1281

Tested in UK, but we will almost certainly stay with OS basemap there (needs to be taken into account when merging upstream - https://github.com/colouring-cities/colouring-core/commit/7ef7fedc3a6fc74262c5c3a580d6d0fb139fd0b9 should be partially reverted then).
![screen03](https://github.com/colouring-cities/colouring-core/assets/899988/be194d5b-1314-49be-9769-6b80a9d4703c)

Test with Acropolis of Athens (no loaded buildings)
![screen04](https://github.com/colouring-cities/colouring-core/assets/899988/bc5a7995-ba04-41bb-a1ac-eeb22239ba53)

Day palette is a bit noisy, maybe colour transformation to desaturate/make colours gray would be a good idea? (like dark mode is achieved, map tiles are the same). But that would be a separate PR.

![screen05](https://github.com/colouring-cities/colouring-core/assets/899988/896f48ea-c9f9-4912-a02b-9578cb5d9ab4)

