### PR TITLE
smarter tile caching

### DIFF
--- a/app/src/tiles/rendererDefinition.ts
+++ b/app/src/tiles/rendererDefinition.ts
@@ -39,12 +39,13 @@ if(!allLayersCacheSwitch) {
         ['base_light', 'base_night', 'base_night_outlines', 'base_boroughs'].includes(tileset) && z <= 18;
 }
 
+const MIN_ZOOM_FOR_RENDERING_TILES = 9
+
 const tileCache = new TileCache(
     process.env.TILECACHE_PATH,
     {
         tilesets: getBuildingLayerNames(),
-        minZoom: 9,
-        maxZoom: 19,
+        minZoom: MIN_ZOOM_FOR_RENDERING_TILES,
         scales: [1, 2]
     },
     shouldCacheFn,
@@ -69,7 +70,12 @@ function stitchOrRenderBuildingTile(tileParams: TileParams, dataParams: any): Pr
 }
 
 function renderTile(tileParams: TileParams, dataParams: any): Promise<Tile> {
-    if (isOutsideExtent(tileParams, EXTENT_BBOX)) {
+    if (isOutsideExtent(tileParams, EXTENT_BBOX) || tileParams.z < MIN_ZOOM_FOR_RENDERING_TILES) {
+        // if tiles are on lower zoom level then producing/caching is expected
+        // then we should short-circuit tile generation
+        // otherwise tile would be generated and not cached
+
+        // also, tiles outside EXTENT_BBOX are not to be produced
         return createBlankTile();
     }
 

--- a/app/src/tiles/tileCache.ts
+++ b/app/src/tiles/tileCache.ts
@@ -53,11 +53,6 @@ interface CacheDomain {
     minZoom: number;
 
     /**
-     * The highest zoom level to cache
-     */
-    maxZoom: number;
-
-    /**
      * An array of scale factors to cache
      */
     scales: number[];
@@ -137,7 +132,6 @@ class TileCache {
     private shouldUseCache(tileParams: TileParams): boolean {
         return this.cacheDomain.tilesets.includes(tileParams.tileset) &&
             this.cacheDomain.minZoom <= tileParams.z &&
-            this.cacheDomain.maxZoom >= tileParams.z &&
             this.cacheDomain.scales.includes(tileParams.scale) &&
             (this.shouldCacheFn == undefined || this.shouldCacheFn(tileParams));
     }


### PR DESCRIPTION
remove max rendering zoom - this was effectively disable already it turns out that caching at high zoom levels is more efficient

short-circuit tile rendering for low zoom levels
it should not happen in normal operations but logs were showing that it was somehow done it could be also done by using direct link to tile this tiles were not cached - making repetitive use impactful on performance