### PR TITLE
Unbreak tile caching.

### DIFF
--- a/app/src/tiles/rendererDefinition.ts
+++ b/app/src/tiles/rendererDefinition.ts
@@ -40,12 +40,14 @@ if(!allLayersCacheSwitch) {
 }
 
 const MIN_ZOOM_FOR_RENDERING_TILES = 9
+const MAX_ZOOM_FOR_RENDERING_TILES = 19
 
 const tileCache = new TileCache(
     process.env.TILECACHE_PATH,
     {
         tilesets: getBuildingLayerNames(),
         minZoom: MIN_ZOOM_FOR_RENDERING_TILES,
+        maxZoom: MAX_ZOOM_FOR_RENDERING_TILES,
         scales: [1, 2]
     },
     shouldCacheFn,
@@ -70,8 +72,11 @@ function stitchOrRenderBuildingTile(tileParams: TileParams, dataParams: any): Pr
 }
 
 function renderTile(tileParams: TileParams, dataParams: any): Promise<Tile> {
-    if (isOutsideExtent(tileParams, EXTENT_BBOX) || tileParams.z < MIN_ZOOM_FOR_RENDERING_TILES) {
-        // if tiles are on lower zoom level then producing/caching is expected
+    if (isOutsideExtent(tileParams, EXTENT_BBOX) 
+        || tileParams.z < MIN_ZOOM_FOR_RENDERING_TILES
+        || tileParams.z > MAX_ZOOM_FOR_RENDERING_TILES
+        ) {
+        // if tiles are outside cache zoom level then producing/caching is expected
         // then we should short-circuit tile generation
         // otherwise tile would be generated and not cached
 

--- a/app/src/tiles/tileCache.ts
+++ b/app/src/tiles/tileCache.ts
@@ -53,6 +53,11 @@ interface CacheDomain {
     minZoom: number;
 
     /**
+     * The highest zoom level to cache
+     */
+    maxZoom: number;
+
+    /**
      * An array of scale factors to cache
      */
     scales: number[];
@@ -132,6 +137,7 @@ class TileCache {
     private shouldUseCache(tileParams: TileParams): boolean {
         return this.cacheDomain.tilesets.includes(tileParams.tileset) &&
             this.cacheDomain.minZoom <= tileParams.z &&
+            this.cacheDomain.maxZoom >= tileParams.z &&
             this.cacheDomain.scales.includes(tileParams.scale) &&
             (this.shouldCacheFn == undefined || this.shouldCacheFn(tileParams));
     }


### PR DESCRIPTION
Fixes and partially reverts fd78eb8cc5d686d4e7dcbef1c54cb2837d760f50

Sadly, removed complexity was actually needed to ensure that cache will be invalidated.

Caught while testing effects of applying security upgrade.