### PR TITLE
Lift length restrictions on planning data strings.

### DIFF
--- a/migrations/053.planning_livestream_lift_restrictions.down.sql
+++ b/migrations/053.planning_livestream_lift_restrictions.down.sql
@@ -1,0 +1,9 @@
+ALTER TABLE planning_data
+    ALTER planning_application_id TYPE VARCHAR(50),
+    ALTER planning_application_link TYPE VARCHAR(260),
+    ALTER status TYPE VARCHAR(50),
+    ALTER status_before_aliasing TYPE VARCHAR(50),
+    ALTER status_explanation_note TYPE VARCHAR(250),
+    ALTER data_source TYPE VARCHAR(70),
+    ALTER data_source_link TYPE VARCHAR(150),
+    ALTER address TYPE VARCHAR(300);

--- a/migrations/053.planning_livestream_lift_restrictions.up.sql
+++ b/migrations/053.planning_livestream_lift_restrictions.up.sql
@@ -1,0 +1,9 @@
+ALTER TABLE planning_data
+    ALTER planning_application_id TYPE VARCHAR,
+    ALTER planning_application_link TYPE VARCHAR,
+    ALTER status TYPE VARCHAR,
+    ALTER status_before_aliasing TYPE VARCHAR,
+    ALTER status_explanation_note TYPE VARCHAR,
+    ALTER data_source TYPE VARCHAR,
+    ALTER data_source_link TYPE VARCHAR,
+    ALTER address TYPE VARCHAR;


### PR DESCRIPTION
See https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_varchar.28n.29_by_default

Import started to fail as at least one link is exceeding 260 characters, limit that seemed reasonable. Lets lift this limits in general here.