### PR TITLE
Make text for category titles smaller.

### DIFF
--- a/app/src/frontend/building/category-link.css
+++ b/app/src/frontend/building/category-link.css
@@ -15,7 +15,7 @@
   .category-title {
     display: block;
     text-align: center;
-    font-size: 0.9em;
+    font-size: 0.8em;
     margin: 0;
     padding: 0.6em;
   }


### PR DESCRIPTION
See #1411

This is a workaround, not a proper fix.