### PR TITLE
Fixes to Construction Year fields

### DIFF
--- a/app/src/api/config/dataFields.ts
+++ b/app/src/api/config/dataFields.ts
@@ -135,6 +135,10 @@ export const buildingAttributesConfig = valueType<DataFieldConfig>()({ /* eslint
         edit: true,
         verify: true,
     },
+    date_year_completed: {
+        edit: true,
+        verify: true,
+    },
     date_lower: {
         edit: true,
         verify: true,

--- a/app/src/frontend/building/data-containers/age-history.tsx
+++ b/app/src/frontend/building/data-containers/age-history.tsx
@@ -78,7 +78,7 @@ const AgeHistoryView: React.FunctionComponent<CategoryViewProps> = (props) => {
 
     return (
         <Fragment>
-            <DataEntryGroup name="Architectural style/historial period" collapsed={subcat==null || subcat!="2"}>
+            <DataEntryGroup name="Architectural style/historical period" collapsed={subcat==null || subcat!="2"}>
                 {(props.mapColourScale != "typology_style_period") ? 
                     <button className={`map-switcher-inline enabled-state btn btn-outline btn-outline-dark key-button`} onClick={switchToStylePeriodMapStyle}>
                         Click to show architectural style.

--- a/app/src/frontend/building/data-containers/age-history.tsx
+++ b/app/src/frontend/building/data-containers/age-history.tsx
@@ -69,7 +69,8 @@ const AgeHistoryView: React.FunctionComponent<CategoryViewProps> = (props) => {
     let construction_length = null;
 
     if (props.building.date_year != null && props.building.date_lower != null) {
-        construction_length += props.building.date_year - props.building.date_lower;
+        construction_length = props.building.date_year - props.building.date_lower;
+        construction_length = Math.max(construction_length, 1);
     }
 
     const queryParameters = new URLSearchParams(window.location.search);
@@ -150,7 +151,7 @@ const AgeHistoryView: React.FunctionComponent<CategoryViewProps> = (props) => {
                     onChange={props.onChange}
                     step={1}
                     min={1}
-                    max={currentYear}
+                    max={props.building.date_year}
                     tooltip={dataFields.date_lower.tooltip}
                     />
                 <Verification
@@ -169,7 +170,7 @@ const AgeHistoryView: React.FunctionComponent<CategoryViewProps> = (props) => {
                     copy={props.copy}
                     onChange={props.onChange}
                     step={1}
-                    min={1}
+                    min={props.building.date_lower}
                     max={currentYear}
                     tooltip={dataFields.date_year.tooltip}
                     />

--- a/app/src/frontend/building/data-containers/age-history.tsx
+++ b/app/src/frontend/building/data-containers/age-history.tsx
@@ -68,8 +68,8 @@ const AgeHistoryView: React.FunctionComponent<CategoryViewProps> = (props) => {
 
     let construction_length = null;
 
-    if (props.building.date_year != null && props.building.date_lower != null) {
-        construction_length = props.building.date_year - props.building.date_lower;
+    if (props.building.date_year != null && props.building.date_year_completed != null) {
+        construction_length = props.building.date_year_completed - props.building.date_year;
         construction_length = Math.max(construction_length, 1);
     }
 
@@ -143,26 +143,6 @@ const AgeHistoryView: React.FunctionComponent<CategoryViewProps> = (props) => {
                     <></>
                 }
                 <NumericDataEntry
-                    title={dataFields.date_lower.title}
-                    slug="date_lower"
-                    value={props.building.date_lower}
-                    mode={props.mode}
-                    copy={props.copy}
-                    onChange={props.onChange}
-                    step={1}
-                    min={1}
-                    max={props.building.date_year}
-                    tooltip={dataFields.date_lower.tooltip}
-                    />
-                <Verification
-                    slug="date_lower"
-                    allow_verify={props.user !== undefined && props.building.date_lower !== null && !props.edited}
-                    onVerify={props.onVerify}
-                    user_verified={props.user_verified.hasOwnProperty("date_lower")}
-                    user_verified_as={props.user_verified.date_lower}
-                    verified_count={props.building.verified.date_lower}
-                    />
-                <NumericDataEntry
                     title={dataFields.date_year.title}
                     slug="date_year"
                     value={props.building.date_year}
@@ -170,8 +150,8 @@ const AgeHistoryView: React.FunctionComponent<CategoryViewProps> = (props) => {
                     copy={props.copy}
                     onChange={props.onChange}
                     step={1}
-                    min={props.building.date_lower}
-                    max={currentYear}
+                    min={1}
+                    max={props.building.date_year_completed}
                     tooltip={dataFields.date_year.tooltip}
                     />
                 <Verification
@@ -181,6 +161,26 @@ const AgeHistoryView: React.FunctionComponent<CategoryViewProps> = (props) => {
                     user_verified={props.user_verified.hasOwnProperty("date_year")}
                     user_verified_as={props.user_verified.date_year}
                     verified_count={props.building.verified.date_year}
+                    />
+                <NumericDataEntry
+                    title={dataFields.date_year_completed.title}
+                    slug="date_year_completed"
+                    value={props.building.date_year_completed}
+                    mode={props.mode}
+                    copy={props.copy}
+                    onChange={props.onChange}
+                    step={1}
+                    min={props.building.date_year}
+                    max={currentYear}
+                    tooltip={dataFields.date_year_completed.tooltip}
+                    />
+                <Verification
+                    slug="date_year_completed"
+                    allow_verify={props.user !== undefined && props.building.date_year_completed !== null && !props.edited}
+                    onVerify={props.onVerify}
+                    user_verified={props.user_verified.hasOwnProperty("date_year_completed")}
+                    user_verified_as={props.user_verified.date_year_completed}
+                    verified_count={props.building.verified.date_year_completed}
                     />
                 <NumericDataEntry
                     title="Estimated duration of construction (years)"

--- a/app/src/frontend/config/data-fields-config.ts
+++ b/app/src/frontend/config/data-fields-config.ts
@@ -524,9 +524,15 @@ export const dataFields = { /* eslint-disable @typescript-eslint/camelcase */
     },
     date_year: {
         category: Category.AgeHistory,
-        title: "Year of construction completed (best estimate)",
-        tooltip: "Best estimate for the year that construction of main body of the building was completed.",
+        title: "Year construction started (best estimate)",
+        tooltip: "Best estimate for the year that construction began on this building.",
         example: 1924,
+    },
+    date_year_completed: {
+        category: Category.AgeHistory,
+        title: "Year construction completed (best estimate)",
+        tooltip: "Best estimate for the year that construction completed on this building.",
+        example: 1925,
     },
     date_lower: {
         category: Category.AgeHistory,

--- a/app/src/frontend/config/data-fields-config.ts
+++ b/app/src/frontend/config/data-fields-config.ts
@@ -556,7 +556,7 @@ export const dataFields = { /* eslint-disable @typescript-eslint/camelcase */
     date_source_links: {
         category: Category.AgeHistory,
         title: "Alternative Source link(s)",
-        tooltip: "URL(s) for historial data source(s) - Alternative data source(s)",
+        tooltip: "URL(s) for historical data source(s) - Alternative data source(s)",
         example: ["", "", ""],
     },
     size_storeys_core: {

--- a/app/src/tiles/dataDefinition.ts
+++ b/app/src/tiles/dataDefinition.ts
@@ -43,6 +43,13 @@ const LAYER_QUERIES = {
         FROM
             buildings
         WHERE date_year IS NOT NULL`,
+    date_year_completed: `
+        SELECT
+            geometry_id,
+            date_year_completed
+        FROM
+            buildings
+        WHERE date_year_completed IS NOT NULL`,
     size_storeys: `
         SELECT
             geometry_id,

--- a/migrations/054.building_age.down.sql
+++ b/migrations/054.building_age.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE buildings DROP COLUMN IF EXISTS date_year_completed;

--- a/migrations/054.building_age.up.sql
+++ b/migrations/054.building_age.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE buildings ADD COLUMN IF NOT EXISTS date_year_completed integer NULL;


### PR DESCRIPTION
After workshopping previous changes with Polly:

- Former "Year of construction (best estimate)" is now "Year construction started".
- "Earliest/Latest Possible Start Year" fields have been disabled and are no longer used.
- Added a new field for "Year construction ended".

Includes typo fix for "historial period".