### PR TITLE
Initial configuration

### DIFF
--- a/app/src/cc-config.json
+++ b/app/src/cc-config.json
@@ -1,19 +1,19 @@
 {
-    "cityName": "Cities",
+    "cityName": "Iceland",
     "institution": "The Alan Turing Institute",
-    "projectBlurb": "Colouring {City Name} is part of Colouring Cities.",
+    "projectBlurb": "Colouring Iceland is part of Colouring Cities.",
     
     "githubURL": "https://github.com/colouring-cities/colouring-core",
     "manualURL": "https://github.com/colouring-cities/manual/wiki/COLOURING-BRITAIN",
     "privacyStatement": "{Privacy statement goes here}",
 
-    "initialMapPosition": [ 51.5245255, -0.1338422 ],
+    "initialMapPosition": [ 64.152774, -21.939547 ],
     "initialZoomLevel": 16,
 
     "postcode": "Postcode",
     "energy_rating": "Building Research Establishment Environmental Assessment Method (BREEAM) rating [<a href='https://bregroup.com/products/breeam/how-breeam-works'>More info</a>]",
 
-    "bbox": [-61149.622628, 6667754.851372, 37183, 6744803.375884],
+    "bbox": [-2460660.8146,9367663.5645,-2413422.7311,9399155.6201],
 
     "basemapTileUrl": "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
     "baseAttribution": "Building attribute data is © Colouring Cities contributors. Basemap © <a href=https://www.openstreetmap.org/copyright>OpenStreetMap contributors</a>. Building © MODIFY TO PROVIDE RELEVANT INFO"

--- a/app/src/frontend/displayPreferences-context.tsx
+++ b/app/src/frontend/displayPreferences-context.tsx
@@ -119,7 +119,7 @@ export const DisplayPreferencesProvider: React.FC<{}> = ({children}) => {
     const defaultFlood = 'disabled'
     const defaultCreative = 'disabled'
     const defaultHousing = 'disabled'
-    const defaultBorough = 'enabled'
+    const defaultBorough = 'disabled'
     const defaultParcel = 'disabled'
     const defaultConservation = 'disabled'
     const defaultHistoricData = 'disabled'


### PR DESCRIPTION
Initial setup of platform variables to focus on Reykjavík.
(Also, disable unused layer to remove Britain-specific text.)