### PR TITLE
Remove tooltips unrelated to these fields.

### DIFF
--- a/app/src/frontend/building/data-containers/age-history.tsx
+++ b/app/src/frontend/building/data-containers/age-history.tsx
@@ -257,7 +257,7 @@ const AgeHistoryView: React.FunctionComponent<CategoryViewProps> = (props) => {
                     step={1}
                     min={1}
                     max={currentYear}
-                    tooltip={dataFields.extension_year.tooltip}
+                    tooltip={dataFields.age_cladding_date.tooltip}
                     />
                 <Verification
                     slug="age_cladding_date"
@@ -307,7 +307,7 @@ const AgeHistoryView: React.FunctionComponent<CategoryViewProps> = (props) => {
                     step={1}
                     min={1}
                     max={currentYear}
-                    tooltip={dataFields.extension_year.tooltip}
+                    tooltip={dataFields.age_extension_date.tooltip}
                     />
                 <Verification
                     slug="age_extension_date"
@@ -357,7 +357,7 @@ const AgeHistoryView: React.FunctionComponent<CategoryViewProps> = (props) => {
                     step={1}
                     min={1}
                     max={currentYear}
-                    tooltip={dataFields.extension_year.tooltip}
+                    tooltip={dataFields.age_retrofit_date.tooltip}
                     />
                 <Verification
                     slug="age_retrofit_date"

--- a/app/src/frontend/building/data-containers/retrofit-condition.tsx
+++ b/app/src/frontend/building/data-containers/retrofit-condition.tsx
@@ -32,7 +32,7 @@ const RetrofitConditionView: React.FunctionComponent<CategoryViewProps> = (props
                     step={1}
                     min={1}
                     max={currentYear}
-                    tooltip={dataFields.extension_year.tooltip}
+                    tooltip={dataFields.age_retrofit_date.tooltip}
                     />
                 <Verification
                     slug="age_retrofit_date"

--- a/app/src/frontend/config/data-fields-config.ts
+++ b/app/src/frontend/config/data-fields-config.ts
@@ -2095,7 +2095,7 @@ export const dataFields = { /* eslint-disable @typescript-eslint/camelcase */
     age_cladding_date: {
         category: Category.AgeHistory,
         title: "Cladding date (best estimate)",
-        tooltip: "Width of the street in metres.",
+        tooltip: null,
         example: 1970
     },
     age_cladding_date_source_type: {
@@ -2114,7 +2114,7 @@ export const dataFields = { /* eslint-disable @typescript-eslint/camelcase */
     age_extension_date: {
         category: Category.AgeHistory,
         title: "Date of significant extensions (best estimate)",
-        tooltip: "Width of the street in metres.",
+        tooltip: null,
         example: 1970
     },
     age_extension_date_source_type: {
@@ -2133,7 +2133,7 @@ export const dataFields = { /* eslint-disable @typescript-eslint/camelcase */
     age_retrofit_date: {
         category: Category.AgeHistory,
         title: "Date of last significant retrofit (best estimate)",
-        tooltip: "Width of the street in metres.",
+        tooltip: null,
         example: 1970
     },
     age_retrofit_date_source_type: {


### PR DESCRIPTION
@polly64 

Should 

> "Cladding date (best estimate)"

> "Date of significant extensions (best estimate)"

> "Date of last significant retrofit (best estimate)"

should get replacement tooltips?

This change removes "Width of the street in metres." that is their current unwanted tooltip.