### PR TITLE
Typescript-friendly children

### DIFF
--- a/app/src/frontend/building/data-components/field-row.tsx
+++ b/app/src/frontend/building/data-components/field-row.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
+import React, { PropsWithChildren } from 'react'
 
 import './field-row.css';
 
-export function FieldRow({children}) {
+export function FieldRow({ children }: PropsWithChildren<{}>): JSX.Element {
     return (
         <div className="field-row">
             {children}


### PR DESCRIPTION
works as it worked before
no longer reports spurious errors