### PR TITLE
Automate calculation of general land use.

### DIFF
--- a/app/src/frontend/building/data-containers/land-use.tsx
+++ b/app/src/frontend/building/data-containers/land-use.tsx
@@ -8,6 +8,7 @@ import { CategoryViewProps } from './category-view-props';
 import Verification from '../data-components/verification';
 import { useDisplayPreferences } from '../../displayPreferences-context';
 import { DataEntryGroup } from '../data-components/data-entry-group';
+import InfoBox from '../../components/info-box';
 
 /**
  * Use view/edit section
@@ -102,6 +103,23 @@ const LandUseView: React.FunctionComponent<CategoryViewProps> = (props) => {
                 />
             </DataEntryGroup>
             <DataEntryGroup name="General Land Use" collapsed={subcat==null || subcat!="2"}>
+                {/*deprecate this field somehow */}
+                <Fragment>
+                    <div className="data-title">
+                        <div className="data-title-text">
+                            <div className="data-title-text">
+                                <label>
+                                    <span>Is the building residential, non-residential or mixed? (automatically generated from Specific Land Use/s)</span>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </Fragment>
+                <InfoBox type='success'>
+                    <Fragment>
+                        {["Mixed Use", "Residential"].includes(props.building.current_landuse_order) ? props.building.current_landuse_order : "Non-residential"}
+                    </Fragment>
+                </InfoBox>
                 {(props.mapColourScale != "is_domestic") ? 
                     <button className={`map-switcher-inline disabled-state btn btn-outline btn-outline-dark key-button`} onClick={switchToIsDomesticMapStyle}>
                         {"Click to see residential, non-residential and mixed-use buildings."}
@@ -109,6 +127,8 @@ const LandUseView: React.FunctionComponent<CategoryViewProps> = (props) => {
                     :
                     <></>
                 }
+                {/* switched to automatically filled based on specific landuse data*/
+                /*
                 <SelectDataEntry
                     title={dataFields.is_domestic.title}
                     slug="is_domestic"
@@ -119,7 +139,6 @@ const LandUseView: React.FunctionComponent<CategoryViewProps> = (props) => {
                     onChange={props.onChange}
                     tooltip={dataFields.is_domestic.tooltip}
                 />
-                {/*
                 <Verification
                     slug="is_domestic"
                     allow_verify={props.user !== undefined && props.building.is_domestic !== null && !props.edited}

--- a/app/src/frontend/building/multi-edit.tsx
+++ b/app/src/frontend/building/multi-edit.tsx
@@ -7,6 +7,7 @@ import InfoBox from '../components/info-box';
 import { allFieldsConfig } from '../config/data-fields-config';
 
 import DataEntry from './data-components/data-entry';
+import { Console } from 'console';
 
 interface MultiEditProps {
     category: string;
@@ -14,7 +15,7 @@ interface MultiEditProps {
 
 const MultiEdit: React.FC<MultiEditProps> = (props) => {
     const [data, error] = useMultiEditData();
-
+    console.log(data);
     return (
         <section className='data-section'>
             <header className={`section-header view ${props.category} background-${props.category}`}>


### PR DESCRIPTION
fixes #1477

@polly64 Should we have special case for hotels? Should they be listed as residential? Probably no, despite their position in classification system.

Or maybe land use style should be followed and should be treated as residential?

remaining TODOs:

(1) handle deprecation of column, maybe delete its data (on the other hand doing it in migration script may be an unpleasant surprise). Keep it forever? Also may be a trap for future users of the code, confused by dead/deprecated fields.

(2) handle map style display

![screen02](https://github.com/user-attachments/assets/a4523a16-24c9-4f42-a970-72f306d4a06c)
![screen01](https://github.com/user-attachments/assets/663cf213-1b51-41a2-92f1-9c724a691ea4)
