### PR TITLE
Fix for number input fields

### DIFF
--- a/app/src/frontend/building/data-components/numeric-data-entry.css
+++ b/app/src/frontend/building/data-components/numeric-data-entry.css
@@ -1,0 +1,9 @@
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+input[type=number]{
+    -moz-appearance: textfield;
+}

--- a/app/src/frontend/building/data-components/numeric-data-entry.tsx
+++ b/app/src/frontend/building/data-components/numeric-data-entry.tsx
@@ -3,6 +3,7 @@ import React, { Fragment } from 'react';
 import { BaseDataEntryProps } from './data-entry';
 import { DataTitleCopyable } from './data-title';
 
+import './numeric-data-entry.css';
 
 interface NumericDataEntryProps extends BaseDataEntryProps {
     value?: number;
@@ -28,6 +29,7 @@ const NumericDataEntry: React.FunctionComponent<NumericDataEntryProps> = (props)
             <input
                 className="form-control"
                 type="number"
+                onWheel={(e) => (e.target as HTMLElement).blur()}
                 id={slugWithModifier}
                 name={slugWithModifier}
                 value={props.value == undefined ? '' : props.value}


### PR DESCRIPTION
- As requested, disable the arrows that let you add or subtract from numerical values.
- Also prevent the number changing when you use the scroll wheel while the field is selected

See: https://github.com/colouring-cities/colouring-britain/issues/254