### PR TITLE
Exagerrate building size for EPC layer to make data more visible on lower zoom levels.

### DIFF
--- a/app/map_styles/polygon.xml
+++ b/app/map_styles/polygon.xml
@@ -2036,37 +2036,39 @@
         <Rule>
             <Filter>[sust_aggregate_estimate_epc] = A</Filter>
             <PolygonSymbolizer fill="#007f3d" />
+            <LineSymbolizer stroke="#007f3d" stroke-width="2.0"/>
         </Rule>
         <Rule>
             <Filter>[sust_aggregate_estimate_epc] = B</Filter>
             <PolygonSymbolizer fill="#2c9f29" />
+            <LineSymbolizer stroke="#2c9f29" stroke-width="2.0"/>
         </Rule>
         <Rule>
             <Filter>[sust_aggregate_estimate_epc] = C</Filter>
             <PolygonSymbolizer fill="#9dcb3c" />
+            <LineSymbolizer stroke="#9dcb3c" stroke-width="2.0"/>
         </Rule>
         <Rule>
             <Filter>[sust_aggregate_estimate_epc] = D</Filter>
             <PolygonSymbolizer fill="#fff200" />
+            <LineSymbolizer stroke="#fff200" stroke-width="2.0"/>
         </Rule>
         <Rule>
             <Filter>[sust_aggregate_estimate_epc] = E</Filter>
             <PolygonSymbolizer fill="#f7af1d" />
+            <LineSymbolizer stroke="#f7af1d" stroke-width="2.0"/>
         </Rule>
         <Rule>
             <Filter>[sust_aggregate_estimate_epc] = F</Filter>
             <PolygonSymbolizer fill="#ed6823" />
+            <LineSymbolizer stroke="#ed6823" stroke-width="2.0"/>
         </Rule>
         <Rule>
             <Filter>[sust_aggregate_estimate_epc] = G</Filter>
             <PolygonSymbolizer fill="#e31d23" />
+            <LineSymbolizer stroke="#e31d23" stroke-width="2.0"/>
         </Rule>
 
-        <Rule>
-            <MaxScaleDenominator>17061</MaxScaleDenominator>
-            <MinScaleDenominator>4264</MinScaleDenominator>
-            <LineSymbolizer stroke="#888" stroke-width="1.0"/>
-        </Rule>
         <Rule>
             <MaxScaleDenominator>4264</MaxScaleDenominator>
             <MinScaleDenominator>0</MinScaleDenominator>


### PR DESCRIPTION
z11 before/after
<img width="873" height="856" alt="z11 before" src="https://github.com/user-attachments/assets/5bcf09ca-dfae-49c6-b34f-f02149fbe289" />
<img width="813" height="1071" alt="z11 now" src="https://github.com/user-attachments/assets/16b575c6-0875-4641-a7dd-deb25aab3d78" />

z13 before/after
<img width="1371" height="726" alt="z13 before" src="https://github.com/user-attachments/assets/61b239d6-0297-4f48-959a-9f909b911e16" />
<img width="864" height="679" alt="z13 now" src="https://github.com/user-attachments/assets/8d6cd278-68c1-4205-9c23-32fabf884479" />
